### PR TITLE
test: configure Brownie not to report coverage for non-protocol contracts

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -17,3 +17,9 @@ compiler:
     remappings:
       - "@openzeppelinV2=OpenZeppelin/openzeppelin-contracts@2.5.1"
       - "@openzeppelinV3=OpenZeppelin/openzeppelin-contracts@3.1.0"
+
+reports:
+  exclude_paths:
+    - contracts/test/Token.sol
+  exclude_contracts:
+    - SafeMath


### PR DESCRIPTION
This will ignore the test Token contract, and SafeMath, which are both using the very well-tested OpenZeppelin library