### PR TITLE
feat(registry): return structs for vault info

### DIFF
--- a/contracts/registries/YRegistry.sol
+++ b/contracts/registries/YRegistry.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
 
 import "@openzeppelinV2/contracts/math/SafeMath.sol";
 import "@openzeppelinV2/contracts/utils/Address.sol";
@@ -22,6 +23,15 @@ contract YRegistry {
     EnumerableSet.AddressSet private vaults;
     EnumerableSet.AddressSet private controllers;
 
+    struct VaultInfo {
+        address vault;
+        address controller;
+        address token;
+        address strategy;
+        bool isWrapped;
+        bool isDelegated;
+    }
+
     mapping(address => address) private wrappedVaults;
 
     mapping(address => bool) public isDelegatedVault;
@@ -38,9 +48,9 @@ contract YRegistry {
     function addVault(address _vault) public onlyGovernance {
         setVault(_vault);
 
-        (address controller, , , , ) = getVaultData(_vault);
+        VaultInfo memory _vaultInfo = getVaultData(_vault);
 
-        setController(controller);
+        setController(_vaultInfo.controller);
     }
 
     function addWrappedVault(address _vault) public onlyGovernance {
@@ -48,10 +58,10 @@ contract YRegistry {
         address wrappedVault = IWrappedVault(_vault).vault();
         setWrappedVault(_vault, wrappedVault);
 
-        (address controller, , , , ) = getVaultData(_vault);
+        VaultInfo memory _vaultInfo = getVaultData(_vault);
 
         // Adds to controllers array
-        setController(controller);
+        setController(_vaultInfo.controller);
         // TODO Add and track tokens and strategies? [historical]
         // (current ones can be obtained via getVaults + getVaultInfo)
     }
@@ -60,10 +70,10 @@ contract YRegistry {
         setVault(_vault);
         setDelegatedVault(_vault);
 
-        (address controller, , , , ) = getVaultData(_vault);
+        VaultInfo memory _vaultInfo = getVaultData(_vault);
 
         // Adds to controllers array
-        setController(controller);
+        setController(_vaultInfo.controller);
         // TODO Add and track tokens and strategies? [historical]
         // (current ones can be obtained via getVaults + getVaultInfo)
     }
@@ -93,32 +103,24 @@ contract YRegistry {
         }
     }
 
-    function getVaultData(address _vault)
-        internal
-        view
-        returns (
-            address controller,
-            address token,
-            address strategy,
-            bool isWrapped,
-            bool isDelegated
-        )
-    {
+    function getVaultData(address _vault) internal view returns (VaultInfo memory vaultInfo) {
         address vault = _vault;
-        isWrapped = wrappedVaults[_vault] != address(0);
+        bool isWrapped = wrappedVaults[_vault] != address(0);
         if (isWrapped) {
             vault = wrappedVaults[_vault];
         }
-        isDelegated = isDelegatedVault[vault];
+        bool isDelegated = isDelegatedVault[vault];
 
         // Get values from controller
-        controller = IVault(vault).controller();
+        address token = address(0);
+        address controller = IVault(vault).controller();
         if (isWrapped && IVault(vault).underlying() != address(0)) {
             token = IVault(_vault).token(); // Use non-wrapped vault
         } else {
             token = IVault(vault).token();
         }
 
+        address strategy = address(0);
         if (isDelegated) {
             strategy = IController(controller).strategies(vault);
         } else {
@@ -143,7 +145,7 @@ contract YRegistry {
             require(token == strategyToken, "Strategy token address does not match"); // Might happen?
         }
 
-        return (controller, token, strategy, isWrapped, isDelegated);
+        return VaultInfo(vault, controller, token, strategy, isWrapped, isDelegated);
     }
 
     // Vaults getters
@@ -163,45 +165,15 @@ contract YRegistry {
         return vaultsArray;
     }
 
-    function getVaultInfo(address _vault)
-        external
-        view
-        returns (
-            address controller,
-            address token,
-            address strategy,
-            bool isWrapped,
-            bool isDelegated
-        )
-    {
-        (controller, token, strategy, isWrapped, isDelegated) = getVaultData(_vault);
-        return (controller, token, strategy, isWrapped, isDelegated);
+    function getVaultInfo(address _vault) external view returns (VaultInfo memory vaultInfo) {
+        return getVaultData(_vault);
     }
 
-    function getVaultsInfo()
-        external
-        view
-        returns (
-            address[] memory controllerArray,
-            address[] memory tokenArray,
-            address[] memory strategyArray,
-            bool[] memory isWrappedArray,
-            bool[] memory isDelegatedArray
-        )
-    {
-        controllerArray = new address[](vaults.length());
-        tokenArray = new address[](vaults.length());
-        strategyArray = new address[](vaults.length());
-        isWrappedArray = new bool[](vaults.length());
-        isDelegatedArray = new bool[](vaults.length());
+    function getVaultsInfo() external view returns (VaultInfo[] memory vaultInfos) {
+        vaultInfos = new VaultInfo[](vaults.length());
 
         for (uint256 i = 0; i < vaults.length(); i++) {
-            (address _controller, address _token, address _strategy, bool _isWrapped, bool _isDelegated) = getVaultData(vaults.get(i));
-            controllerArray[i] = _controller;
-            tokenArray[i] = _token;
-            strategyArray[i] = _strategy;
-            isWrappedArray[i] = _isWrapped;
-            isDelegatedArray[i] = _isDelegated;
+            vaultInfos[i] = getVaultData(vaults.get(i));
         }
     }
 

--- a/tests/functional/registries/test_registries.py
+++ b/tests/functional/registries/test_registries.py
@@ -5,7 +5,7 @@ from brownie import (
     yVault,
     yWETH,
     yDelegatedVault,
-    YRegistry,
+    YRegistryV2,
     StrategyCreamYFI,
     StrategyMKRVaultDAIDelegate,
     Controller,
@@ -13,8 +13,8 @@ from brownie import (
 
 
 def test_registry_deployment(gov):
-    registry = gov.deploy(YRegistry, gov)
-    assert registry.getName() == "YRegistry"
+    registry = gov.deploy(YRegistryV2, gov)
+    assert registry.getName() == "YRegistryV2"
     assert registry.governance() == gov
 
 
@@ -22,7 +22,7 @@ def test_registry_add_vault(accounts, gov, rewards):
     token = "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
     controller = gov.deploy(Controller, rewards)
     vault = gov.deploy(yVault, token, controller)
-    registry = gov.deploy(YRegistry, gov)
+    registry = gov.deploy(YRegistryV2, gov)
     strategy = gov.deploy(StrategyCreamYFI, controller)
 
     controller.setVault(token, vault, {"from": gov})
@@ -49,7 +49,7 @@ def test_registry_add_delegated_vault(accounts, gov, rewards):
     token = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     controller = gov.deploy(Controller, rewards)
     vault = gov.deploy(yDelegatedVault, token, controller)
-    registry = gov.deploy(YRegistry, gov)
+    registry = gov.deploy(YRegistryV2, gov)
     strategy = gov.deploy(StrategyMKRVaultDAIDelegate, controller)
 
     controller.setVault(strategy, vault, {"from": gov})

--- a/tests/functional/registries/test_registries.py
+++ b/tests/functional/registries/test_registries.py
@@ -1,0 +1,72 @@
+import pytest
+import brownie
+
+from brownie import (
+    yVault,
+    yWETH,
+    yDelegatedVault,
+    YRegistry,
+    StrategyCreamYFI,
+    StrategyMKRVaultDAIDelegate,
+    Controller,
+)
+
+
+def test_registry_deployment(gov):
+    registry = gov.deploy(YRegistry, gov)
+    assert registry.getName() == "YRegistry"
+    assert registry.governance() == gov
+
+
+def test_registry_add_vault(accounts, gov, rewards):
+    token = "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
+    controller = gov.deploy(Controller, rewards)
+    vault = gov.deploy(yVault, token, controller)
+    registry = gov.deploy(YRegistry, gov)
+    strategy = gov.deploy(StrategyCreamYFI, controller)
+
+    controller.setVault(token, vault, {"from": gov})
+    controller.approveStrategy(token, strategy, {"from": gov})
+    controller.setStrategy(token, strategy, {"from": gov})
+
+    # Only governance can set this param
+    with brownie.reverts("Only governance can call this function."):
+        registry.addVault(vault, {"from": accounts[1]})
+    registry.addVault(vault, {"from": gov})
+    assert registry.getVault(0) == vault
+
+    fields = ["vault", "controller", "token", "strategy", "is_wrapped", "is_delegated"]
+    vaultInfo = dict(zip(fields, registry.getVaultInfo(vault)))
+    assert vaultInfo["vault"] == vault
+    assert vaultInfo["controller"] == controller
+    assert vaultInfo["token"] == token
+    assert vaultInfo["strategy"] == strategy
+    assert vaultInfo["is_wrapped"] == False
+    assert vaultInfo["is_delegated"] == False
+
+
+def test_registry_add_delegated_vault(accounts, gov, rewards):
+    token = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    controller = gov.deploy(Controller, rewards)
+    vault = gov.deploy(yDelegatedVault, token, controller)
+    registry = gov.deploy(YRegistry, gov)
+    strategy = gov.deploy(StrategyMKRVaultDAIDelegate, controller)
+
+    controller.setVault(strategy, vault, {"from": gov})
+    controller.approveStrategy(vault, strategy, {"from": gov})
+    controller.setStrategy(vault, strategy, {"from": gov})
+
+    # Only governance can set this param
+    with brownie.reverts("Only governance can call this function."):
+        registry.addVault(vault, {"from": accounts[1]})
+    registry.addDelegatedVault(vault, {"from": gov})
+    assert registry.getVault(0) == vault
+
+    fields = ["vault", "controller", "token", "strategy", "is_wrapped", "is_delegated"]
+    vaultInfo = dict(zip(fields, registry.getVaultInfo(vault)))
+    assert vaultInfo["vault"] == vault
+    assert vaultInfo["controller"] == controller
+    assert vaultInfo["token"] == token
+    assert vaultInfo["strategy"] == strategy
+    assert vaultInfo["is_wrapped"] == False
+    assert vaultInfo["is_delegated"] == True


### PR DESCRIPTION
As requested in #11, `getVaultInfo` now returns a struct containing all relevant data