### PR TITLE
fix: SPDX license identifier and missing peer dependencies 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,662 +1,517 @@
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
+SPDX-License-Idnetifier: SSPL-1.0 
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
 
-                            Preamble
 
-  The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
+Server Side Public License, v 1 
+==============================================================================
 
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-our General Public Licenses are intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.
 
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
+VERSION 1, OCTOBER 16, 2018
 
-  Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
+Copyright © 2018 MongoDB, Inc.
 
-  A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate.  Many developers of free software are heartened and
-encouraged by the resulting cooperation.  However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
 
-  The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community.  It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server.  Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
+TERMS AND CONDITIONS
 
-  An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals.  This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
+0. Definitions. ----------------------------------------------------------------
 
-  The precise terms and conditions for copying, distribution and
-modification follow.
+"This License" refers to Server Side Public License.
 
-                       TERMS AND CONDITIONS
+"Copyright" also means copyright-like laws that apply to other kinds of works,
+such as semiconductor masks.
 
-  0. Definitions.
+"The Program" refers to any copyrightable work licensed under this License. Each
+licensee is addressed as "you". "Licensees" and "recipients" may be individuals
+or organizations.
 
-  "This License" refers to version 3 of the GNU Affero General Public License.
+To "modify" a work means to copy from or adapt all or part of the work in a
+fashion requiring copyright permission, other than the making of an exact copy.
+The resulting work is called a "modified version" of the earlier work or a work
+"based on" the earlier work.
 
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
+A "covered work" means either the unmodified Program or a work based on the
+Program.
 
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
+To "propagate" a work means to do anything with it that, without permission,
+would make you directly or secondarily liable for infringement under applicable
+copyright law, except executing it on a computer or modifying a private copy.
+Propagation includes copying, distribution (with or without modification),
+making available to the public, and in some countries other activities as well.
 
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
+To "convey" a work means any kind of propagation that enables other parties to
+make or receive copies. Mere interaction with a user through a computer network,
+with no transfer of a copy, is not conveying.
 
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
+An interactive user interface displays "Appropriate Legal Notices" to the extent
+that it includes a convenient and prominently visible feature that (1) displays
+an appropriate copyright notice, and (2) tells the user that there is no
+warranty for the work (except to the extent that warranties are provided), that
+licensees may convey the work under this License, and how to view a copy of this
+License. If the interface presents a list of user commands or options, such as a
 menu, a prominent item in the list meets this criterion.
 
-  1. Source Code.
+1. Source Code. ------------------------------------------------------------------
 
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
+The "source code" for a work means the preferred form of the work for making
+modifications to it. "Object code" means any non-source form of a work.
 
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
+A "Standard Interface" means an interface that either is an official standard
+defined by a recognized standards body, or, in the case of interfaces specified
+for a particular programming language, one that is widely used among developers
+working in that language.
 
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
+The "System Libraries" of an executable work include anything, other than the
+work as a whole, that (a) is included in the normal form of packaging a Major
+Component, but which is not part of that Major Component, and (b) serves only to
+enable use of the work with that Major Component, or to implement a Standard
+Interface for which an implementation is available to the public in source code
+form. A "Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system (if any) on
+which the executable work runs, or a compiler used to produce the work, or an
+object code interpreter used to run it.
 
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
+The "Corresponding Source" for a work in object code form means all the source
+code needed to generate, install, and (for an executable work) run the object
+code and to modify the work, including scripts to control those activities.
+However, it does not include the work's System Libraries, or general-purpose
+tools or generally available free programs which are used unmodified in
+performing those activities but which are not part of the work. For example,
+Corresponding Source includes interface definition files associated with source
+files for the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require, such as by
+intimate data communication or control flow between those subprograms and other
+parts of the work.
 
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
+The Corresponding Source need not include anything that users can regenerate
+automatically from other parts of the Corresponding Source.
 
-  The Corresponding Source for a work in source code form is that
-same work.
+The Corresponding Source for a work in source code form is that same work.
 
-  2. Basic Permissions.
+2. Basic Permissions. ------------------------------------------------------------
 
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
+All rights granted under this License are granted for the term of copyright on
+the Program, and are irrevocable provided the stated conditions are met. This
+License explicitly affirms your unlimited permission to run the unmodified
+Program, subject to section 13. The output from running a covered work is
+covered by this License only if the output, given its content, constitutes a
+covered work. This License acknowledges your rights of fair use or other
+equivalent, as provided by copyright law.
 
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
+Subject to section 13, you may make, run and propagate covered works that you do
+not convey, without conditions so long as your license otherwise remains in
+force. You may convey covered works to others for the sole purpose of having
+them make modifications exclusively for you, or provide you with facilities for
+running those works, provided that you comply with the terms of this License in
+conveying all material for which you do not control copyright. Those thus making
+or running the covered works for you must do so exclusively on your behalf,
+under your direction and control, on terms that prohibit them from making any
+copies of your copyrighted material outside their relationship with you.
 
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
+Conveying under any other circumstances is permitted solely under the conditions
+stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
 
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+------------------------------------------------------------------------------------
 
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
+No covered work shall be deemed part of an effective technological measure under
+any applicable law fulfilling obligations under article 11 of the WIPO copyright
+treaty adopted on 20 December 1996, or similar laws prohibiting or restricting
+circumvention of such measures.
 
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
+When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention is
+effected by exercising rights under this License with respect to the covered
+work, and you disclaim any intention to limit operation or modification of the
+work as a means of enforcing, against the work's users, your or third parties'
+legal rights to forbid circumvention of technological measures.
 
-  4. Conveying Verbatim Copies.
+4. Conveying Verbatim Copies. -------------------------------------------------------
 
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
+You may convey verbatim copies of the Program's source code as you receive it,
+in any medium, provided that you conspicuously and appropriately publish on each
+copy an appropriate copyright notice; keep intact all notices stating that this
+License and any non-permissive terms added in accord with section 7 apply to the
+code; keep intact all notices of the absence of any warranty; and give all
 recipients a copy of this License along with the Program.
 
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
+You may charge any price or no price for each copy that you convey, and you may
+offer support or warranty protection for a fee.
 
-  5. Conveying Modified Source Versions.
+5. Conveying Modified Source Versions. -----------------------------------------
 
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
+You may convey a work based on the Program, or the modifications to produce it
+from the Program, in the form of source code under the terms of section 4,
+provided that you also meet all of these conditions:
 
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
+a) The work must carry prominent notices stating that you modified it, and
+giving a relevant date. b) The work must carry prominent notices stating that it
+is released under this License and any conditions added under section 7. This
+requirement modifies the requirement in section 4 to "keep intact all notices".
+c)You must license the entire work, as a whole, under this License to anyone who
+comes into possession of a copy. This License will therefore apply, along with
+any applicable section 7 additional terms, to the whole of the work, and all its
+parts, regardless of how they are packaged. This License gives no permission to
+license the work in any other way, but it does not invalidate such permission if
+you have separately received it. d)If the work has interactive user interfaces,
+each must display Appropriate Legal Notices; however, if the Program has
+interactive interfaces that do not display Appropriate Legal Notices, your work
+need not make them do so. A compilation of a covered work with other separate
+and independent works, which are not by their nature extensions of the covered
+work, and which are not combined with it such as to form a larger program, in or
+on a volume of a storage or distribution medium, is called an "aggregate" if the
+compilation and its resulting copyright are not used to limit the access or
+legal rights of the compilation's users beyond what the individual works permit.
+Inclusion of a covered work in an aggregate does not cause this License to apply
+to the other parts of the aggregate.
 
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
+6. Conveying Non-Source Forms. ---------------------------------------------------
 
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
+You may convey a covered work in object code form under the terms of sections 4
+and 5, provided that you also convey the machine-readable Corresponding Source
+under the terms of this License, in one of these ways:
 
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
+a) Convey the object code in, or embodied in, a physical product (including a
+physical distribution medium), accompanied by the Corresponding Source fixed on
+a durable physical medium customarily used for software interchange. b) Convey
+the object code in, or embodied in, a physical product (including a physical
+distribution medium), accompanied by a written offer, valid for at least three
+years and valid for as long as you offer spare parts or customer support for
+that product model, to give anyone who possesses the object code either (1) a
+copy of the Corresponding Source for all the software in the product that is
+covered by this License, on a durable physical medium customarily used for
+software interchange, for a price no more than your reasonable cost of
+physically performing this conveying of source, or (2) access to copy the
+Corresponding Source from a network server at no charge. c) Convey individual
+copies of the object code with a copy of the written offer to provide the
+Corresponding Source. This alternative is allowed only occasionally and
+noncommercially, and only if you received the object code with such an offer, in
+accord with subsection 6b. d) Convey the object code by offering access from a
+designated place (gratis or for a charge), and offer equivalent access to the
+Corresponding Source in the same way through the same place at no further
+charge. You need not require recipients to copy the Corresponding Source along
+with the object code. If the place to copy the object code is a network server,
+the Corresponding Source may be on a different server (operated by you or a
+third party) that supports equivalent copying facilities, provided you maintain
+clear directions next to the object code saying where to find the Corresponding
+Source. Regardless of what server hosts the Corresponding Source, you remain
+obligated to ensure that it is available for as long as needed to satisfy these
+requirements. e) Convey the object code using peer-to-peer transmission,
+provided you inform other peers where the object code and Corresponding Source
+of the work are being offered to the general public at no charge under
+subsection 6d. A separable portion of the object code, whose source code is
+excluded from the Corresponding Source as a System Library, need not be included
+in conveying the object code work.
 
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
+A "User Product" is either (1) a "consumer product", which means any tangible
+personal property which is normally used for personal, family, or household
+purposes, or (2) anything designed or sold for incorporation into a dwelling. In
+determining whether a product is a consumer product, doubtful cases shall be
+resolved in favor of coverage. For a particular product received by a particular
+user, "normally used" refers to a typical or common use of that class of
+product, regardless of the status of the particular user or of the way in which
+the particular user actually uses, or expects or is expected to use, the
+product. A product is a consumer product regardless of whether the product has
+substantial commercial, industrial or non-consumer uses, unless such uses
+represent the only significant mode of use of the product.
 
-  6. Conveying Non-Source Forms.
+"Installation Information" for a User Product means any methods, procedures,
+authorization keys, or other information required to install and execute
+modified versions of a covered work in that User Product from a modified version
+of its Corresponding Source. The information must suffice to ensure that the
+continued functioning of the modified object code is in no case prevented or
+interfered with solely because modification has been made.
 
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
+If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as part of a
+transaction in which the right of possession and use of the User Product is
+transferred to the recipient in perpetuity or for a fixed term (regardless of
+how the transaction is characterized), the Corresponding Source conveyed under
+this section must be accompanied by the Installation Information. But this
+requirement does not apply if neither you nor any third party retains the
+ability to install modified object code on the User Product (for example, the
+work has been installed in ROM).
 
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
+The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates for a
+work that has been modified or installed by the recipient, or for the User
+Product in which it has been modified or installed. Access to a network may be
+denied when the modification itself materially and adversely affects the
+operation of the network or violates the rules and protocols for communication
+across the network.
 
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
+Corresponding Source conveyed, and Installation Information provided, in accord
+with this section must be in a format that is publicly documented (and with an
+implementation available to the public in source code form), and must require no
+special password or key for unpacking, reading or copying.
 
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
+7. Additional Terms. ----------------------------------------------------------
 
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
+"Additional permissions" are terms that supplement the terms of this License by
+making exceptions from one or more of its conditions. Additional permissions
+that are applicable to the entire Program shall be treated as though they were
+included in this License, to the extent that they are valid under applicable
+law. If additional permissions apply only to part of the Program, that part may
+be used separately under those permissions, but the entire Program remains
+governed by this License without regard to the additional permissions.
 
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
+When you convey a copy of a covered work, you may at your option remove any
+additional permissions from that copy, or from any part of it. (Additional
+permissions may be written to require their own removal in certain cases when
+you modify the work.) You may place additional permissions on material, added by
+you to a covered work, for which you have or can give appropriate copyright
+permission.
 
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
+Notwithstanding any other provision of this License, for material you add to a
+covered work, you may (if authorized by the copyright holders of that material)
+supplement the terms of this License with terms:
 
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
+a)Disclaiming warranty or limiting liability differently from the terms of
+sections 15 and 16 of this License; or b) Requiring preservation of specified
+reasonable legal notices or author attributions in that material or in the
+Appropriate Legal Notices displayed by works containing it; or c) Prohibiting
+misrepresentation of the origin of that material, or requiring that modified
+versions of such material be marked in reasonable ways as different from the
+original version; or d) Limiting the use for publicity purposes of names of
+licensors or authors of the material; or e) Declining to grant rights under
+trademark law for use of some trade names, trademarks, or service marks; or f)
+Requiring indemnification of licensors and authors of that material by anyone
+who conveys the material (or modified versions of it) with contractual
+assumptions of liability to the recipient, for any liability that these
+contractual assumptions directly impose on those licensors and authors. All
+other non-permissive additional terms are considered "further restrictions"
+within the meaning of section 10. If the Program as you received it, or any part
+of it, contains a notice stating that it is governed by this License along with
+a term that is a further restriction, you may remove that term. If a license
+document contains a further restriction but permits relicensing or conveying
+under this License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does not survive
+such relicensing or conveying.
 
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
+If you add terms to a covered work in accord with this section, you must place,
+in the relevant source files, a statement of the additional terms that apply to
+those files, or a notice indicating where to find the applicable terms.
 
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
+Additional terms, permissive or non-permissive, may be stated in the form of a
+separately written license, or stated as exceptions; the above requirements
+apply either way.
 
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
+8.Termination. --------------------------------------------------------------------
 
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
+You may not propagate or modify a covered work except as expressly provided
+under this License. Any attempt otherwise to propagate or modify it is void, and
+will automatically terminate your rights under this License (including any
+patent licenses granted under the third paragraph of section 11).
 
-  7. Additional Terms.
+However, if you cease all violation of this License, then your license from a
+particular copyright holder is reinstated (a) provisionally, unless and until
+the copyright holder explicitly and finally terminates your license, and (b)
+permanently, if the copyright holder fails to notify you of the violation by
+some reasonable means prior to 60 days after the cessation.
 
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
+Moreover, your license from a particular copyright holder is reinstated
+permanently if the copyright holder notifies you of the violation by some
+reasonable means, this is the first time you have received notice of violation
+of this License (for any work) from that copyright holder, and you cure the
+violation prior to 30 days after your receipt of the notice.
 
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
+Termination of your rights under this section does not terminate the licenses of
+parties who have received copies or rights from you under this License. If your
+rights have been terminated and not permanently reinstated, you do not qualify
+to receive new licenses for the same material under section 10.
 
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
+9. Acceptance Not Required for Having Copies.
+---------------------------------------------------------------------------
 
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
+You are not required to accept this License in order to receive or run a copy of
+the Program. Ancillary propagation of a covered work occurring solely as a
+consequence of using peer-to-peer transmission to receive a copy likewise does
+not require acceptance. However, nothing other than this License grants you
+permission to propagate or modify any covered work. These actions infringe
+copyright if you do not accept this License. Therefore, by modifying or
+propagating a covered work, you indicate your acceptance of this License to do
+so.
 
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
+10. Automatic Licensing of Downstream Recipients.
+-------------------------------------------------------------------------------
 
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
+Each time you convey a covered work, the recipient automatically receives a
+license from the original licensors, to run, modify and propagate that work,
+subject to this License. You are not responsible for enforcing compliance by
+third parties with this License.
 
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
+An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
+organization, or merging organizations. If propagation of a covered work results
+from an entity transaction, each party to that transaction who receives a copy
+of the work also receives whatever licenses to the work the party's predecessor
+in interest had or could give under the previous paragraph, plus a right to
+possession of the Corresponding Source of the work from the predecessor in
+interest, if the predecessor has it or can get it with reasonable efforts.
 
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
+You may not impose any further restrictions on the exercise of the rights
+granted or affirmed under this License. For example, you may not impose a
+license fee, royalty, or other charge for exercise of rights granted under this
+License, and you may not initiate litigation (including a cross-claim or
+counterclaim in a lawsuit) alleging that any patent claim is infringed by
+making, using, selling, offering for sale, or importing the Program or any
+portion of it.
 
-  11. Patents.
+11. Patents. -------------------------------------------------------------------
 
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
+A "contributor" is a copyright holder who authorizes use under this License of
+the Program or a work on which the Program is based. The work thus licensed is
+called the contributor's "contributor version".
 
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
+A contributor's "essential patent claims" are all patent claims owned or
+controlled by the contributor, whether already acquired or hereafter acquired,
+that would be infringed by some manner, permitted by this License, of making,
+using, or selling its contributor version, but do not include claims that would
+be infringed only as a consequence of further modification of the contributor
+version. For purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of this License.
 
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent
+license under the contributor's essential patent claims, to make, use, sell,
+offer for sale, import and otherwise run, modify and propagate the contents of
+its contributor version.
 
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
+In the following three paragraphs, a "patent license" is any express agreement
+or commitment, however denominated, not to enforce a patent (such as an express
+permission to practice a patent or covenant not to sue for patent infringement).
+To "grant" such a patent license to a party means to make such an agreement or
+commitment not to enforce a patent against the party.
 
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
+If you convey a covered work, knowingly relying on a patent license, and the
+Corresponding Source of the work is not available for anyone to copy, free of
+charge and under the terms of this License, through a publicly available network
+server or other readily accessible means, then you must either (1) cause the
+Corresponding Source to be so available, or (2) arrange to deprive yourself of
+the benefit of the patent license for this particular work, or (3) arrange, in a
+manner consistent with the requirements of this License, to extend the patent
+license to downstream recipients. "Knowingly relying" means you have actual
+knowledge that, but for the patent license, your conveying the covered work in a
+country, or your recipient's use of the covered work in a country, would
+infringe one or more identifiable patents in that country that you have reason
+to believe are valid.
 
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
+If, pursuant to or in connection with a single transaction or arrangement, you
+convey, or propagate by procuring conveyance of, a covered work, and grant a
+patent license to some of the parties receiving the covered work authorizing
+them to use, propagate, modify or convey a specific copy of the covered work,
+then the patent license you grant is automatically extended to all recipients of
+the covered work and works based on it.
 
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
+A patent license is "discriminatory" if it does not include within the scope of
+its coverage, prohibits the exercise of, or is conditioned on the non-exercise
+of one or more of the rights that are specifically granted under this License.
+You may not convey a covered work if you are a party to an arrangement with a
+third party that is in the business of distributing software, under which you
+make payment to the third party based on the extent of your activity of
+conveying the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory patent
+license (a) in connection with copies of the covered work conveyed by you (or
+copies made from those copies), or (b) primarily for and in connection with
+specific products or compilations that contain the covered work, unless you
+entered into that arrangement, or that patent license was granted, prior to 28
+March 2007.
 
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
+Nothing in this License shall be construed as excluding or limiting any implied
+license or other defenses to infringement that may otherwise be available to you
+under applicable patent law.
 
-  12. No Surrender of Others' Freedom.
+12. No Surrender of Others' Freedom. --------------------------------------
 
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
+If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not excuse
+you from the conditions of this License. If you cannot use, propagate or convey
+a covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may not
+use, propagate or convey it at all. For example, if you agree to terms that
+obligate you to collect a royalty for further conveying from those to whom you
+convey the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Remote Network Interaction; Use with the GNU General Public License.
+13. Offering the Program as a Service. ----------------------------------------
 
-  Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software.  This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
+If you make the functionality of the Program or a modified version available to
+third parties as a service, you must make the Service Source Code available via
+network download to everyone at no charge, under the terms of this License.
+Making the functionality of the Program or modified version available to third
+parties as a service includes, without limitation, enabling third parties to
+interact with the functionality of the Program or modified version remotely
+through a computer network, offering a service the value of which entirely or
+primarily derives from the value of the Program or modified version, or offering
+a service that accomplishes for users the primary purpose of the Program or
+modified version.
 
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
+"Service Source Code" means the Corresponding Source for the Program or the
+modified version, and the Corresponding Source for all programs that you use to
+make the Program or modified version available as a service, including, without
+limitation, management software, user interfaces, application program
+interfaces, automation software, monitoring software, backup software, storage
+software and hosting software, all such that a user could run an instance of the
+service using the Service Source Code you make available.
 
-  14. Revised Versions of this License.
+14. Revised Versions of this License. ----------------------------------------
 
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new versions
-will be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
+MongoDB, Inc. may publish revised and/or new versions of the Server Side Public
+License from time to time. Such new versions will be similar in spirit to the
+present version, but may differ in detail to address new problems or concerns.
 
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
-by the Free Software Foundation.
+Each version is given a distinguishing version number. If the Program specifies
+that a certain numbered version of the Server Side Public License "or any later
+version" applies to it, you have the option of following the terms and
+conditions either of that numbered version or of any later version published by
+MongoDB, Inc. If the Program does not specify a version number of the Server
+Side Public License, you may choose any version ever published by MongoDB, Inc.
 
-  If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
+If the Program specifies that a proxy can decide which future versions of the
+Server Side Public License can be used, that proxy's public statement of
+acceptance of a version permanently authorizes you to choose that version for
+the Program.
 
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
+Later license versions may give you additional or different permissions.
+However, no additional obligations are imposed on any author or copyright holder
+as a result of your choosing to follow a later version.
 
-  15. Disclaimer of Warranty.
+15. Disclaimer of Warranty. -----------------------------------------------------
 
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER
+EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE
+QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE
+DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-  16. Limitation of Liability.
+16. Limitation of Liability. -----------------------------------------------------
 
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY
+COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS
+PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL,
+INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE
+THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
+PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY
+HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
-  17. Interpretation of Sections 15 and 16.
+17. Interpretation of Sections 15 and 16.
+----------------------------------------------------------------------------------
 
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
+If the disclaimer of warranty and limitation of liability provided above cannot
+be given local legal effect according to their terms, reviewing courts shall
+apply local law that most closely approximates an absolute waiver of all civil
+liability in connection with the Program, unless a warranty or assumption of
+liability accompanies a copy of the Program in return for a fee.
 
-                     END OF TERMS AND CONDITIONS
 
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
-<https://www.gnu.org/licenses/>.
-
+This program is free software: you can redistribute it and/or modify it under
+the terms of the Server Side Public License, version 1, as published by MongoDB,
+Inc. This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the Server Side Public License for more details.
+You should have received a copy of the Server Side Public License along with
+this program.
+<http://www.mongodb.com/licensing/server-side-public-license>.

--- a/contracts/controllers/Controller.sol
+++ b/contracts/controllers/Controller.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/controllers/Controller.sol
+++ b/contracts/controllers/Controller.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/controllers/DelegatedController.sol
+++ b/contracts/controllers/DelegatedController.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/controllers/DelegatedController.sol
+++ b/contracts/controllers/DelegatedController.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/exploits/EvilGauge.sol
+++ b/contracts/exploits/EvilGauge.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity =0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/registries/YRegistry.sol
+++ b/contracts/registries/YRegistry.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/registries/YRegistry.sol
+++ b/contracts/registries/YRegistry.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/math/SafeMath.sol";

--- a/contracts/strategies/CurveYCRVVoter.sol
+++ b/contracts/strategies/CurveYCRVVoter.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/CurveYCRVVoter.sol
+++ b/contracts/strategies/CurveYCRVVoter.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyCreamYFI.sol
+++ b/contracts/strategies/StrategyCreamYFI.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyCreamYFI.sol
+++ b/contracts/strategies/StrategyCreamYFI.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyCurve3CrvVoterProxy.sol
+++ b/contracts/strategies/StrategyCurve3CrvVoterProxy.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyCurveBTCVoterProxy.sol
+++ b/contracts/strategies/StrategyCurveBTCVoterProxy.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyCurveBTCVoterProxy.sol
+++ b/contracts/strategies/StrategyCurveBTCVoterProxy.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyCurveBUSDVoterProxy.sol
+++ b/contracts/strategies/StrategyCurveBUSDVoterProxy.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyCurveBUSDVoterProxy.sol
+++ b/contracts/strategies/StrategyCurveBUSDVoterProxy.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyCurveYVoterProxy.sol
+++ b/contracts/strategies/StrategyCurveYVoterProxy.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyCurveYVoterProxy.sol
+++ b/contracts/strategies/StrategyCurveYVoterProxy.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyDAICurve.sol
+++ b/contracts/strategies/StrategyDAICurve.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyDAICurve.sol
+++ b/contracts/strategies/StrategyDAICurve.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyDForceUSDC.sol
+++ b/contracts/strategies/StrategyDForceUSDC.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyDForceUSDC.sol
+++ b/contracts/strategies/StrategyDForceUSDC.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyDForceUSDT.sol
+++ b/contracts/strategies/StrategyDForceUSDT.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyDForceUSDT.sol
+++ b/contracts/strategies/StrategyDForceUSDT.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyMKRVaultDAIDelegate.sol
+++ b/contracts/strategies/StrategyMKRVaultDAIDelegate.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyProxy.sol
+++ b/contracts/strategies/StrategyProxy.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyProxy.sol
+++ b/contracts/strategies/StrategyProxy.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyTUSDCurve.sol
+++ b/contracts/strategies/StrategyTUSDCurve.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyTUSDCurve.sol
+++ b/contracts/strategies/StrategyTUSDCurve.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyVaultUSDC.sol
+++ b/contracts/strategies/StrategyVaultUSDC.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyVaultUSDC.sol
+++ b/contracts/strategies/StrategyVaultUSDC.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/strategies/StrategyYFIGovernance.sol
+++ b/contracts/strategies/StrategyYFIGovernance.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/contracts/strategies/StrategyYFIGovernance.sol
+++ b/contracts/strategies/StrategyYFIGovernance.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/ERC20.sol";

--- a/contracts/utils/BTCOSMedianizer.sol
+++ b/contracts/utils/BTCOSMedianizer.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/math/SafeMath.sol";

--- a/contracts/utils/ETHOSMedianizer.sol
+++ b/contracts/utils/ETHOSMedianizer.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 import "../../interfaces/maker/OracleSecurityModule.sol";

--- a/contracts/vaults/yDelegatedVault.sol
+++ b/contracts/vaults/yDelegatedVault.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/vaults/yVault.sol
+++ b/contracts/vaults/yVault.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/contracts/vaults/yWETH.sol
+++ b/contracts/vaults/yWETH.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 import "@openzeppelinV2/contracts/token/ERC20/IERC20.sol";

--- a/interfaces/aave/Aave.sol
+++ b/interfaces/aave/Aave.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface Aave {

--- a/interfaces/aave/AaveToken.sol
+++ b/interfaces/aave/AaveToken.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface AaveToken {

--- a/interfaces/aave/LendingPoolAddressesProvider.sol
+++ b/interfaces/aave/LendingPoolAddressesProvider.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface LendingPoolAddressesProvider {

--- a/interfaces/aave/Oracle.sol
+++ b/interfaces/aave/Oracle.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface Oracle {

--- a/interfaces/compound/Token.sol
+++ b/interfaces/compound/Token.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/compound/Token.sol
+++ b/interfaces/compound/Token.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface cToken {

--- a/interfaces/cream/Controller.sol
+++ b/interfaces/cream/Controller.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/cream/Controller.sol
+++ b/interfaces/cream/Controller.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface Creamtroller {

--- a/interfaces/curve/Curve.sol
+++ b/interfaces/curve/Curve.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/curve/Curve.sol
+++ b/interfaces/curve/Curve.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface ICurveFi {

--- a/interfaces/curve/Gauge.sol
+++ b/interfaces/curve/Gauge.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/curve/Gauge.sol
+++ b/interfaces/curve/Gauge.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface Gauge {

--- a/interfaces/curve/Mintr.sol
+++ b/interfaces/curve/Mintr.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/curve/Mintr.sol
+++ b/interfaces/curve/Mintr.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface Mintr {

--- a/interfaces/curve/VoteEscrow.sol
+++ b/interfaces/curve/VoteEscrow.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/curve/VoteEscrow.sol
+++ b/interfaces/curve/VoteEscrow.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface VoteEscrow {

--- a/interfaces/dforce/Rewards.sol
+++ b/interfaces/dforce/Rewards.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/dforce/Rewards.sol
+++ b/interfaces/dforce/Rewards.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface dRewards {

--- a/interfaces/dforce/Token.sol
+++ b/interfaces/dforce/Token.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/dforce/Token.sol
+++ b/interfaces/dforce/Token.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface dERC20 {

--- a/interfaces/maker/Maker.sol
+++ b/interfaces/maker/Maker.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface GemLike {

--- a/interfaces/maker/OracleSecurityModule.sol
+++ b/interfaces/maker/OracleSecurityModule.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface OracleSecurityModule {

--- a/interfaces/uniswap/Uni.sol
+++ b/interfaces/uniswap/Uni.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/uniswap/Uni.sol
+++ b/interfaces/uniswap/Uni.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface Uni {

--- a/interfaces/weth/WETH.sol
+++ b/interfaces/weth/WETH.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface WETH {

--- a/interfaces/yearn/IController.sol
+++ b/interfaces/yearn/IController.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IController.sol
+++ b/interfaces/yearn/IController.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IController {

--- a/interfaces/yearn/IConverter.sol
+++ b/interfaces/yearn/IConverter.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IConverter {

--- a/interfaces/yearn/IConverter.sol
+++ b/interfaces/yearn/IConverter.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IDelegatedVault.sol
+++ b/interfaces/yearn/IDelegatedVault.sol
@@ -1,3 +1,4 @@
+/// SPDX-License-Identifier: SSPL-1.0
 pragma solidity ^0.5.17;
 
 interface IDelegatedVault {

--- a/interfaces/yearn/IGovernance.sol
+++ b/interfaces/yearn/IGovernance.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IGovernance.sol
+++ b/interfaces/yearn/IGovernance.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IGovernance {

--- a/interfaces/yearn/IOneSplitAudit.sol
+++ b/interfaces/yearn/IOneSplitAudit.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IOneSplitAudit.sol
+++ b/interfaces/yearn/IOneSplitAudit.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IOneSplitAudit {

--- a/interfaces/yearn/IProxy.sol
+++ b/interfaces/yearn/IProxy.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IProxy.sol
+++ b/interfaces/yearn/IProxy.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IProxy {

--- a/interfaces/yearn/IStrategy.sol
+++ b/interfaces/yearn/IStrategy.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IStrategy.sol
+++ b/interfaces/yearn/IStrategy.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IStrategy {

--- a/interfaces/yearn/IToken.sol
+++ b/interfaces/yearn/IToken.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IToken.sol
+++ b/interfaces/yearn/IToken.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 // NOTE: Basically an alias for Vaults

--- a/interfaces/yearn/IVault.sol
+++ b/interfaces/yearn/IVault.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IVault.sol
+++ b/interfaces/yearn/IVault.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IVault {

--- a/interfaces/yearn/IVoterProxy.sol
+++ b/interfaces/yearn/IVoterProxy.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IVoterProxy.sol
+++ b/interfaces/yearn/IVoterProxy.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IVoterProxy {

--- a/interfaces/yearn/IWrappedVault.sol
+++ b/interfaces/yearn/IWrappedVault.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: SSPL-1.0
+
 
 pragma solidity ^0.5.17;
 

--- a/interfaces/yearn/IWrappedVault.sol
+++ b/interfaces/yearn/IWrappedVault.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: SSPL-1.0
 
-
 pragma solidity ^0.5.17;
 
 interface IWrappedVault {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
             "pre-commit": "yarn lint:fix",
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
         }
+    },
+    "peerDependencies": {
+        "solium": "^1.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,6 +2366,25 @@ solium-plugin-security@0.1.1:
   resolved "https://registry.yarnpkg.com/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz#2a87bcf8f8c3abf7d198e292e4ac080284e3f3f6"
   integrity sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ==
 
+solium@^1.0.0:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/solium/-/solium-1.2.5.tgz#d036c30e2901e22137bbf342f106b17529ff22a8"
+  integrity sha512-NuNrm7fp8JcDN/P+SAdM5TVa4wYDtwVtLY/rG4eBOZrC5qItsUhmQKR/YhjszaEW4c8tNUYhkhQcwOsS25znpw==
+  dependencies:
+    ajv "^5.2.2"
+    chokidar "^1.6.0"
+    colors "^1.1.2"
+    commander "^2.9.0"
+    diff "^3.5.0"
+    eol "^0.9.1"
+    js-string-escape "^1.0.1"
+    lodash "^4.14.2"
+    sol-digger "0.0.2"
+    sol-explore "1.6.1"
+    solium-plugin-security "0.1.1"
+    solparse "2.2.8"
+    text-table "^0.2.0"
+
 solparse@2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/solparse/-/solparse-2.2.8.tgz#d13e42dbed95ce32f43894f5ec53f00d14cf9f11"


### PR DESCRIPTION
### SPDX 

this pull request changes `// SPDX-License-Identifier: MIT` to reflect the newer license of `/// SPDX-License-Identifier: SSPL-1.0` 

> note - `///` usage for `solc` warnings even tho 

#### AGPL vs SSPL

See a `diff` here: [AGPL_vs_SSPL](https://gist.github.com/sambacha/bb914c3ff1041503e80a70651e62184f)

> tl;dr SSPL addresses issues of SaaS usage, mainly distributing the software over a network and not disclosing interfaces, etc


### Previous PR 
#47 and #60 
closed previous PR, #47  to address styling changes 

### Notes
in the future, there should be a 'dummy' git account in which automated processes (such as CI/CD/etc) can be assigned to, e.g. `git config user.email git@iearn.finance ` in order to assist in the review process / diff'ing / etc, esp. considering increasing amounts of outside contributors, and other automated services (ci pipelines, etc)

### yEarn Bot

see [https://github.com/yearnbot](https://github.com/yearnbot)

example for usage in `prettier`: [https://github.com/yearnBot/vcs/tree/main/bin](https://github.com/yearnBot/vcs/tree/main/bin)

> I did not use this in this PR as there is no point

#### Optional Header

```
Copyright 2020 - yearn protocol contributors  

This program is free software: you can redistribute it
and/or modify it under the terms of the Server Side Public
License, version 1, as published by MongoDB, Inc.
See the Server Side Public License for more details. You should
have received a copy of the Server Side Public License
along with this program.

<http://www.mongodb.com/licensing/server-side-public-license>.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty
of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 

```