### PR TITLE
Add gauge weight voter strategy

### DIFF
--- a/contracts/strategies/StrategyGaugeWeightVoter.sol
+++ b/contracts/strategies/StrategyGaugeWeightVoter.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.5.17;
+
+interface Proxy {
+    function vote(address _gauge, uint256 _amount) external;
+}
+
+contract StrategyGaugeWeightVoter {
+    address public governance;
+    address public strategist;
+    address public proxy;
+
+    constructor(address _proxy) public {
+        governance = msg.sender;
+        strategist = msg.sender;
+        proxy = _proxy;
+    }
+
+    function setGovernance(address _governance) public {
+        require(msg.sender == governance, "!authorized");
+        governance = _governance;
+    }
+
+    function setStrategist(address _strategist) public {
+        require(msg.sender == governance, "!authorized");
+        strategist = _strategist;
+    }
+
+    function setProxy(address _proxy) public {
+        require(msg.sender == governance, "!authorized");
+        proxy = _proxy;
+    }
+
+    function vote(address[] memory gauges, uint[] memory weights) public {
+        require(msg.sender == governance || msg.sender == strategist, "!authorized");
+        for (uint i=0; i<gauges.length; i++) {
+            Proxy(proxy).vote(gauges[i], weights[i]);
+        }
+    }
+}


### PR DESCRIPTION
This hooks into StrategyProxy and allows voting for Curve Gauge weight allocations.

A script to determine optimal allocations:
https://gist.github.com/banteg/546720079b63dd44ff149f2dfe4b9c34

Rationale: `vote` method in StrategyProxy is only callable by connected strategies, so this is a safe and secure way to isolate the voting.

Adding voting in Curve DAO (`0xE478de485ad2fe566d49342Cbd03E49ed7DB3356.vote(uint256,bool,bool)`) might be tricky since StrategyProxy doesn't expose a method to vote there.