### PR TITLE
Maker OSM wrapper

### DIFF
--- a/contracts/utils/MakerOracle.vy
+++ b/contracts/utils/MakerOracle.vy
@@ -32,12 +32,14 @@ def set_user(user: address, allowed: bool):
 @view
 @external
 def peek() -> (uint256, bool):
-    assert self.users[msg.sender]
+    assert self.users[msg.sender], "not user"
+    assert self.oracle.bud(self), "not bud"
     return self.oracle.peek()
 
 
 @view
 @external
 def peep() -> (uint256, bool):
-    assert self.users[msg.sender]
+    assert self.users[msg.sender], "not user"
+    assert self.oracle.bud(self), "not bud"
     return self.oracle.peep()

--- a/contracts/utils/MakerOracle.vy
+++ b/contracts/utils/MakerOracle.vy
@@ -1,0 +1,43 @@
+# @version 0.2.7
+
+interface OSM:
+    def bud(user: address) -> (bool): view
+    def peek() -> (uint256, bool): view
+    def peep() -> (uint256, bool): view
+
+
+owner: public(address)
+users: public(HashMap[address, bool])
+oracle: public(OSM)
+
+
+@external
+def __init__(src: address):
+    self.owner = msg.sender
+    self.oracle = OSM(src)
+
+
+@external
+def set_owner(new_owner: address):
+    assert msg.sender == self.owner
+    self.owner = new_owner
+
+
+@external
+def set_user(user: address, allowed: bool):
+    assert msg.sender == self.owner
+    self.users[user] = allowed
+
+
+@view
+@external
+def peek() -> (uint256, bool):
+    assert self.users[msg.sender]
+    return self.oracle.peek()
+
+
+@view
+@external
+def peep() -> (uint256, bool):
+    assert self.users[msg.sender]
+    return self.oracle.peep()

--- a/interfaces/maker/OracleSecurityModule.sol
+++ b/interfaces/maker/OracleSecurityModule.sol
@@ -6,4 +6,6 @@ interface OracleSecurityModule {
     function peep() external view returns (bytes32, bool);
 
     function bud(address) external view returns (uint256);
+
+    function kiss(address a) external;
 }

--- a/tests/functional/utils/test_maker_oracle.py
+++ b/tests/functional/utils/test_maker_oracle.py
@@ -15,6 +15,7 @@ def test_maker_oracle(MakerOracle, accounts, interface, name):
     deployer, reader = accounts[:2]
     oracle = MakerOracle.deploy(source, {"from": deployer})
     oracle.set_user(reader, True)
+    assert oracle.users(reader)
     for func in [oracle.peek, oracle.peep]:
         with brownie.reverts("not user"):
             func()
@@ -23,5 +24,6 @@ def test_maker_oracle(MakerOracle, accounts, interface, name):
     source.kiss(oracle, {"from": osm_mom})
     for func in [oracle.peek, oracle.peep]:
         val, has = func({"from": reader})
+        print(val.to('ether'), has)
         assert val > 0
         assert has

--- a/tests/functional/utils/test_maker_oracle.py
+++ b/tests/functional/utils/test_maker_oracle.py
@@ -1,0 +1,20 @@
+import brownie
+
+
+def test_yfi_oracle(MakerOracle, accounts, Contract):
+    osm_mom = accounts.at("0x76416A4d5190d071bfed309861527431304aA14f", force=True)
+    yfi_usd_osm = Contract("0x5F122465bCf86F45922036970Be6DD7F58820214")
+    deployer, reader = accounts[:2]
+    oracle = MakerOracle.deploy(yfi_usd_osm, {"from": deployer})
+    oracle.set_user(reader, True)
+    brk_a = 345_592
+    for func in [oracle.peek, oracle.peep]:
+        with brownie.reverts("not user"):
+            func()
+        with brownie.reverts("not bud"):
+            func({"from": reader})
+    yfi_usd_osm.kiss["address"](oracle, {"from": osm_mom})
+    for func in [oracle.peek, oracle.peep]:
+        val, has = func({"from": reader})
+        assert val.to("ether") > brk_a
+        assert has

--- a/tests/functional/utils/test_maker_oracle.py
+++ b/tests/functional/utils/test_maker_oracle.py
@@ -24,6 +24,16 @@ def test_maker_oracle(MakerOracle, accounts, interface, name):
     source.kiss(oracle, {"from": osm_mom})
     for func in [oracle.peek, oracle.peep]:
         val, has = func({"from": reader})
-        print(val.to('ether'), has)
+        print(val.to("ether"), has)
         assert val > 0
         assert has
+
+
+def test_maker_oracle_auth(MakerOracle, accounts):
+    deployer, owner, rando = accounts[:3]
+    oracle = MakerOracle.deploy(oracles["YFI/USD"], {"from": deployer})
+    assert oracle.owner() == deployer
+    oracle.set_owner(owner)
+    assert oracle.owner() == owner
+    with brownie.reverts():
+        oracle.set_owner(rando, {"from": rando})


### PR DESCRIPTION
Rewritten OSM wrapper in Vyper, removed the fallback.

The rationale is if Maker feed is down, something is seriously wrong and the strategy needs to unwind anyway.