### PR TITLE
feat: add linter support script for non-staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "scripts": {
         "lint": "pretty-quick --pattern '**/*.*(sol|json|md)' --verbose",
         "lint:check": "prettier --check **/*.sol **/*.json **/*.md",
-        "lint:fix": "pretty-quick --pattern '**/*.*(sol|json|md)' --staged --verbose"
+        "lint:fix": "pretty-quick --pattern '**/*.*(sol|json|md)' --verbose",
+        "lint:fix-staged": "pretty-quick --pattern '**/*.*(sol|json|md)' --staged --verbose"
     },
     "husky": {
         "hooks": {
-            "pre-commit": "yarn lint:fix",
+            "pre-commit": "yarn lint:fix-staged",
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
         }
     }


### PR DESCRIPTION
Note: Mostly "nice to have" small change to add script for applying linter fix without files needing to be staged. Helps contributors that don't have husky pre hook install. @orbxball 

Change Log:
* add script command for `lint:fix` and `lint:fix-staged` 
* configure husky to use `lint:fix-staged`