### PR TITLE
feat: fix and optimize 3CRV claim logic in StrategyProxy

### DIFF
--- a/contracts/strategies/StrategyProxy.sol
+++ b/contracts/strategies/StrategyProxy.sol
@@ -115,13 +115,11 @@ contract StrategyProxy {
 
     function claim(address recipient) external {
         require(msg.sender == yveCRV, "!strategy");
-        if (now < lastTimeCursor) return;
+        if (now < lastTimeCursor.add(604800)) return;
 
-        while (feeDistribution.last_token_time() > feeDistribution.time_cursor_of(address(proxy))) {
-            address p = address(proxy);
-            feeDistribution.claim_many([p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p]);
-        }
-        lastTimeCursor = feeDistribution.time_cursor();
+        address p = address(proxy);
+        feeDistribution.claim_many([p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p]);
+        lastTimeCursor = feeDistribution.time_cursor_of(address(proxy));
 
         uint256 amount = IERC20(CRV3).balanceOf(address(proxy));
         if (amount > 0) {

--- a/contracts/strategies/StrategyProxy.sol
+++ b/contracts/strategies/StrategyProxy.sol
@@ -30,6 +30,8 @@ contract StrategyProxy {
     mapping(address => bool) public voters;
     address public governance;
 
+    uint256 lastTimeCursor;
+
     constructor() public {
         governance = msg.sender;
     }
@@ -113,7 +115,15 @@ contract StrategyProxy {
 
     function claim(address recipient) external {
         require(msg.sender == yveCRV, "!strategy");
-        uint256 amount = feeDistribution.claim(address(proxy));
+        if (now < lastTimeCursor) return;
+
+        while (feeDistribution.last_token_time() > feeDistribution.time_cursor_of(address(proxy))) {
+            address p = address(proxy);
+            feeDistribution.claim_many([p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p]);
+        }
+        lastTimeCursor = feeDistribution.time_cursor();
+
+        uint256 amount = IERC20(CRV3).balanceOf(address(proxy));
         if (amount > 0) {
             proxy.execute(CRV3, 0, abi.encodeWithSignature("transfer(address,uint256)", recipient, amount));
         }

--- a/interfaces/curve/FeeDistribution.sol
+++ b/interfaces/curve/FeeDistribution.sol
@@ -1,5 +1,11 @@
 pragma solidity ^0.5.17;
 
 interface FeeDistribution {
-    function claim(address) external returns (uint256);
+    function claim_many(address[20] calldata) external returns (bool);
+
+    function last_token_time() external view returns (uint256);
+
+    function time_cursor() external view returns (uint256);
+
+    function time_cursor_of(address) external view returns (uint256);
 }


### PR DESCRIPTION
### What I did

This PR fixes an issue within `StrategyProxy` where externally claimed 3CRV is not detected:

* Curve's `FeeDistributor.claim` method is unguarded - any address can trigger a claim for another address.
* The current implementation of `StrategyProxy` relies on the return value from `claim` in order to know the size of the claim.
* Thus, when a claim is triggered outside of `StrategyProxy`, the amount is not detected and not passed onto `yveCRV`.

Additionally, there is a claim performed on every single call. This is inefficient for two reasons:

1. Claiming only is possible once a week. The majority of these calls have no effect.
2. When it _is_ possible to claim, the user epoch only advances by 50 points per claim. Due to he number of locking / extending actions performed each week, there are usually >50 points to advance. In the past week alone there were over 400.

### How I did it

The logical flow introduced in this PR works as such:

1. `FeeDistributor.time_cursor()` is stored locally as `lastTimeCursor`.  This variable is [used within `FeeDistributor`](https://github.com/curvefi/curve-dao-contracts/blob/master/contracts/FeeDistributor.vy#L311) to determine when new fees should be made claimable. At the start of each claim, if `now < lastTimeCursor` we can be certain there are no fees that can be claimed.
2. `FeeDistributor` [calculates claimable fees](https://github.com/curvefi/curve-dao-contracts/blob/master/contracts/FeeDistributor.vy#L264) by iterating until `last_token_time < time_cursor_of[acct]`.  We can claim in a loop until we see that this is condition is met, and be certain that all fees are claimed.  By using `claim_many` we perform up to 20 "rounds" with each call.
3. Finally, we use `3CRV.balanceOf` to get the actual available balance. This way, even fees that were claimed via a third-party call will be seen.
